### PR TITLE
Removed apt-get install arg that downloaded latest certificate.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y libaio1 && rm -rf /var/lib/apt/lists/*
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 RUN gpg --keyserver pgp.mit.edu --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
-RUN apt-get update && apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://dev.mysql.com/get/Downloads/MySQL-5.1/mysql-5.1.73-linux-x86_64-glibc23.tar.gz" -o mysql.tar.gz \
 	&& apt-get purge -y --auto-remove curl \
 	&& mkdir /usr/local/mysql \


### PR DESCRIPTION
* Curl was failing as needed latest certificate installed
* I don't consider this a problem as curl is purged from the image